### PR TITLE
Potential fix for code scanning alert no. 1: Client-side cross-site scripting

### DIFF
--- a/frontend/src/components/Login.vue
+++ b/frontend/src/components/Login.vue
@@ -2,7 +2,7 @@
   <div>
     <div v-if="hasError" class="uk-alert-danger" uk-alert>
       <a class="uk-alert-close" uk-close></a>
-      <p v-html="error"></p>
+      <p>{{ error }}</p>
     </div>
     <div class="uk-flex uk-flex-center uk-flex-middle uk-text-center">
       <div class="uk-card uk-card-default">


### PR DESCRIPTION
Potential fix for [https://github.com/fabio195/ghas-jonthebeach/security/code-scanning/1](https://github.com/fabio195/ghas-jonthebeach/security/code-scanning/1)

To fix the issue, we need to ensure that the `error` value is sanitized before being rendered in the DOM. The best approach is to avoid using `v-html` unless absolutely necessary. Instead, we can bind the `error` value to the DOM using text interpolation (`{{ error }}`), which automatically escapes any HTML content, making it safe from XSS attacks.

If rendering raw HTML is unavoidable, we should sanitize the `error` value using a library like `DOMPurify` before assigning it to `v-html`. This ensures that only safe HTML is rendered.

In this case, we will replace the `v-html` directive with text interpolation (`{{ error }}`) to eliminate the need for raw HTML rendering.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
